### PR TITLE
Strongly type API transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
         "rate",
         "flood",
         "limit"
-    ]
+    ],
+    "dependencies": {
+        "grammy": "^1.12.0"
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
+import { Transformer } from "grammy";
+
 function pause(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, 1000 * seconds))
 }
-
-type AutoRetryTransformer = (...args: any[]) => any
 
 /**
  * Options that can be specified when creating an auto retry transformer
@@ -59,11 +59,12 @@ export interface AutoRetryOptions {
  */
 export function autoRetry(
     options?: Partial<AutoRetryOptions>
-): AutoRetryTransformer {
+): Transformer {
     const maxDelay = options?.maxDelaySeconds ?? 3600
     const maxRetries = options?.maxRetryAttempts ?? 3
     const retryOnInternalServerErrors =
         options?.retryOnInternalServerErrors ?? false
+
     return async (prev, method, payload, signal) => {
         let remainingAttempts = maxRetries
         let result = await prev(method, payload, signal)


### PR DESCRIPTION
While implementing a transformer of my own, I tried looking at this repo for an example and felt it would have helped better if it was strongly typed.

I realized this might be intentional in order to avoid having grammy as a dependency, so let me know if maybe a comment explaining why and a link to [it's type](https://github.com/grammyjs/grammY/blob/main/src/core/client.ts#L71) might be better instead.