### PR TITLE
feat: Add logging to autoRetry plugin 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,12 @@
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "debug": "^4.3.4"
+    },
     "devDependencies": {
-        "typescript": "^4.2.4"
+        "typescript": "^4.2.4",
+        "@types/debug": "^4.1.7"
     },
     "files": [
         "out/"

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export function autoRetry(
                 typeof result.parameters?.retry_after === 'number' &&
                 result.parameters.retry_after <= maxDelay
             ) {
-                debug(`Will retry ${method} after ${result.parameters.retry_after} seconds`);
+                debug(`Hit rate limit, will retry '${method}' after ${result.parameters.retry_after} seconds`);
                 await pause(result.parameters.retry_after)
                 retry = true
             } else if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,8 @@ export function autoRetry(
                 result.parameters.retry_after <= maxDelay
             ) {
                 if (logging === true) {
-                    console.log(`Retry after ${result.parameters.retry_after} seconds`);
+                    const timeString = new Date().toLocaleString();
+                    console.log(`[${timeString}] Retrying after ${result.parameters.retry_after} seconds`);
                 }
                 await pause(result.parameters.retry_after)
                 retry = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { debug as d } from "debug";
-const debug = d("auto-retry");
+const debug = d("grammy:auto-retry");
 
 function pause(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, 1000 * seconds))

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,7 @@ export function autoRetry(
                 typeof result.parameters?.retry_after === 'number' &&
                 result.parameters.retry_after <= maxDelay
             ) {
-                const timeString = new Date().toLocaleString();
-                debug(`[${timeString}] Retrying ${method} after ${result.parameters.retry_after} seconds`);
+                debug(`Will retry ${method} after ${result.parameters.retry_after} seconds`);
                 await pause(result.parameters.retry_after)
                 retry = true
             } else if (


### PR DESCRIPTION
This commit adds a new option to the autoRetry transformer function that enables logging of retry attempts. If the option is set to true, the function will log the retry-after time for each failed request. The option can be passed to the function as a property of the options object.

The logging option is disabled by default, and does not affect the behavior of the function in any way when it is disabled.