### PR TITLE
chore: refactor to Deno project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-[*]
-end_of_line = lf
-charset = utf-8
-indent_style = space
-indent_size = 4
-insert_final_newline = true
-trim_trailing_whitespace = true
-max_line_length = 80

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": false,
-    "arrowParens": "avoid"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": { "source.fixAll": true }
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit"
+    },
+    "deno.enable": true,
+    "deno.config": "./deno.jsonc"
 }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Automatically Retry grammY API Requests
 
 Check out [the official documentation](https://grammy.dev/plugins/auto-retry.html) for this grammY plugin.
+You might also want to read about [broadcasting messages](https://grammy.dev/advanced/flood#how-to-broadcast-messages).
 
 ## Quickstart
 
-An [API transformer function](https://grammy.dev/advanced/transformers.html) let's you modify outgoing HTTP requests on the fly.
+An [API transformer function](https://grammy.dev/advanced/transformers.html) lets you modify outgoing HTTP requests on the fly.
 This grammY plugin can automatically detect if an API requests fails with a `retry_after` value.
 It will then intercept the error, wait the specified period of time, and then retry the request.
 
 ```ts
-import { autoRetry } from '@grammyjs/auto-retry'
+import { autoRetry } from "@grammyjs/auto-retry";
 
 // Install the plugin
-bot.api.config.use(autoRetry())
+bot.api.config.use(autoRetry());
 ```
 
 You may pass an options object that specifies a maximum number of retries (`maxRetryAttempts`, default: 3), or a threshold for a maximal time to wait (`maxDelaySeconds`, default: 1 hour).
@@ -22,7 +23,7 @@ Other errors will be passed on, so the request will fail.
 autoRetry({
     maxRetryAttempts: 1,
     maxDelaySeconds: 5,
-})
+});
 ```
 
 You can use `retryOnInternalServerErrors` to automatically retry all other internal server errors by Telegram (status code >= 500).

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,7 @@
+{
+    "lock": false,
+    "fmt": {
+        "proseWrap": "preserve",
+        "indentWidth": 4
+    }
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,5 +3,9 @@
     "fmt": {
         "proseWrap": "preserve",
         "indentWidth": 4
-    }
+    },
+    "exclude": [
+        "./out/",
+        "./node_modules/"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "url": "https://github.com/grammyjs/auto-retry/issues"
     },
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "prepare": "npm run build"
     },
     "dependencies": {
         "debug": "^4.3.4"
@@ -28,10 +29,10 @@
     "files": [
         "out/"
     ],
-    "main": "out/index.js",
+    "main": "out/mod.js",
     "type": "commonjs",
     "exports": {
-        ".": "./out/index.js"
+        ".": "./out/mod.js"
     },
     "keywords": [
         "retry",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
         "url": "https://github.com/grammyjs/auto-retry/issues"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "deno2node",
         "prepare": "npm run build"
     },
     "dependencies": {
         "debug": "^4.3.4"
     },
     "devDependencies": {
-        "typescript": "^4.2.4",
-        "@types/debug": "^4.1.7"
+        "@types/debug": "^4.1.7",
+        "deno2node": "^1.11.0"
     },
     "files": [
         "out/"
@@ -41,6 +41,7 @@
         "grammy",
         "rate",
         "flood",
-        "limit"
+        "limit",
+        "broadcast"
     ]
 }

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -1,0 +1,12 @@
+import debug from "https://cdn.skypack.dev/debug@4.3.4";
+export { debug };
+const DEBUG = "DEBUG";
+if (typeof Deno !== "undefined") {
+    debug.useColors = () => !Deno.noColor;
+    const env = { name: "env", variable: DEBUG } as const;
+    const res = await Deno.permissions.query(env);
+    let namespace: string | undefined = undefined;
+    if (res.state === "granted") namespace = Deno.env.get(DEBUG);
+    if (namespace) debug.enable(namespace);
+    else debug.disable();
+}

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,0 +1,1 @@
+export { debug } from "debug";


### PR DESCRIPTION
This is sort of a Node project that works on Deno using `esm.sh`. That is not in line with the rest of the ecosystem, and it hinders us from building good tooling around this plugin.

This PQ refactors this project to be a Deno-first project.