### PR TITLE
feat: retry on HttpError

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "dependencies": {
         "debug": "^4.3.4"
     },
+    "peerDependencies": {
+        "grammy": "^1.10.0"
+    },
     "devDependencies": {
         "@types/debug": "^4.1.7",
         "deno2node": "^1.11.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/node": "^12.20.55",
+        "abort-controller": "^3.0.0",
         "deno2node": "^1.11.0"
     },
     "files": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "devDependencies": {
         "@types/debug": "^4.1.7",
+        "@types/node": "^12.20.55",
         "deno2node": "^1.11.0"
     },
     "files": [

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,13 +6,16 @@ const ONE_HOUR = 3600; // seconds
 const INITIAL_LAST_DELAY = 3; // seconds
 
 function pause(seconds: number, signal?: AbortSignal) {
-    return new Promise<void>((resolve) => {
-        const handle = setTimeout(done, 1000 * seconds);
-        signal?.addEventListener("abort", done);
-        function done() {
-            clearTimeout(handle);
-            signal?.removeEventListener("abort", done);
+    return new Promise<void>((resolve, reject) => {
+        const handle = setTimeout(() => {
+            signal?.removeEventListener("abort", abort);
             resolve();
+        }, 1000 * seconds);
+        signal?.addEventListener("abort", abort);
+        function abort() {
+            clearTimeout(handle);
+            signal?.removeEventListener("abort", abort);
+            reject(new Error("Request aborted while waiting between retries"));
         }
     });
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,14 +1,21 @@
 import { debug as d } from "./platform.deno.ts";
 const debug = d("grammy:auto-retry");
+import { HttpError, type Transformer } from "./platform.deno.ts";
 
-const ONE_HOUR = 60 * 60 * 1000; // ms
-const INITIAL_LAST_DELAY = 3000; // ms
+const ONE_HOUR = 3600; // seconds
+const INITIAL_LAST_DELAY = 3; // seconds
 
-function pause(seconds: number) {
-    return new Promise((resolve) => setTimeout(resolve, 1000 * seconds));
+function pause(seconds: number, signal?: AbortSignal) {
+    return new Promise<void>((resolve) => {
+        const handle = setTimeout(done, 1000 * seconds);
+        signal?.addEventListener("abort", done);
+        function done() {
+            clearTimeout(handle);
+            signal?.removeEventListener("abort", done);
+            resolve();
+        }
+    });
 }
-
-type AutoRetryTransformer = (...args: any[]) => any;
 
 /**
  * Options that can be specified when creating an auto retry transformer
@@ -38,18 +45,32 @@ export interface AutoRetryOptions {
     maxRetryAttempts: number;
     /**
      * Requests to the Telegram servers can sometimes encounter internal server
-     * errors (error with status code >= 500). Those are usually not something you
-     * can fix. They often are temporary networking issues, but even if they
-     * persist, they require a fix by the web server or any potential proxies. It
-     * is therefore the best strategy to retry such errors automatically, which is
-     * what this plugin does by default.
+     * errors (error with status code >= 500). Those are usually not something
+     * you can fix in your code. They often are temporary networking issues, but
+     * even if they persist, they require a fix by the web server or any
+     * potential proxies. It is therefore the best strategy to retry such errors
+     * automatically, which is what this plugin does by default.
      *
      * Set this option to `true` if the plugin should rethrow internal server
-     * errors rather than retrying them automatically.
+     * errors rather than retrying the respective requests automatically.
      *
      * (https://en.m.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors)
      */
     rethrowInternalServerErrors: boolean;
+    /**
+     * Network requests can sometimes fail, especially when the network
+     * connection is flaky or unstable, or when intermediate hops are rebooting
+     * or are unreliable. When a network request fails in this way, grammY
+     * throws an `HttpError`. If these errors only happen occasionally, it is
+     * usually not something that you can fix in your code. It is therefore the
+     * best strategy to retry such errors automatically, which is what this
+     * plugin does by default.
+     *
+     * Set this option to `true` if the plugin should rethrow networking errors
+     * (`HttpError` instances) rather than retrying the respective requests
+     * automatically.
+     */
+    rethrowNetworkingErrors: boolean;
 }
 
 /**
@@ -64,19 +85,46 @@ export interface AutoRetryOptions {
  * @param options Configuration options
  * @returns The created API transformer function
  */
-export function autoRetry(
-    options?: Partial<AutoRetryOptions>,
-): AutoRetryTransformer {
+export function autoRetry(options?: Partial<AutoRetryOptions>): Transformer {
     const maxDelay = options?.maxDelaySeconds ?? Infinity;
     const maxRetries = options?.maxRetryAttempts ?? Infinity;
     const rethrowInternalServerErrors = options?.rethrowInternalServerErrors ??
         false;
+    const rethrowNetworkingErrors = options?.rethrowNetworkingErrors ?? false;
     return async (prev, method, payload, signal) => {
         let remainingAttempts = maxRetries;
-        let result = await prev(method, payload, signal);
-        let lastDelay = INITIAL_LAST_DELAY;
-        while (!result.ok && remainingAttempts-- > 0) {
+        let nextDelay = INITIAL_LAST_DELAY;
+
+        async function backoff() {
+            await pause(nextDelay, signal);
+            // exponential backoff, capped at one hour
+            nextDelay = Math.min(ONE_HOUR, nextDelay + nextDelay);
+        }
+        async function call() {
+            let res: ReturnType<typeof prev> | undefined = undefined;
+            while (res === undefined) {
+                try {
+                    res = await prev(method, payload, signal);
+                } catch (e) {
+                    if (!rethrowNetworkingErrors && e instanceof HttpError) {
+                        debug(
+                            `HttpError thrown, will retry '${method}' after ${nextDelay} seconds (${e.message})`,
+                        );
+                        await backoff();
+                        continue;
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+            return res;
+        }
+
+        let result: ReturnType<typeof prev> | undefined = undefined;
+        do {
             let retry = false;
+            result = await call();
+
             if (
                 typeof result.parameters?.retry_after === "number" &&
                 result.parameters.retry_after <= maxDelay
@@ -84,21 +132,21 @@ export function autoRetry(
                 debug(
                     `Hit rate limit, will retry '${method}' after ${result.parameters.retry_after} seconds`,
                 );
-                await pause(result.parameters.retry_after);
-                lastDelay = INITIAL_LAST_DELAY;
+                await pause(result.parameters.retry_after, signal);
+                nextDelay = INITIAL_LAST_DELAY;
                 retry = true;
             } else if (
                 result.error_code >= 500 &&
                 !rethrowInternalServerErrors
             ) {
-                await pause(lastDelay);
-                // exponential backoff, capped at one hour
-                lastDelay = Math.min(ONE_HOUR, lastDelay + lastDelay);
+                debug(
+                    `Hit internal server error, will retry '${method}' after ${nextDelay} seconds`,
+                );
+                await backoff();
                 retry = true;
             }
             if (!retry) return result;
-            else result = await prev(method, payload, signal);
-        }
+        } while (!result.ok && remainingAttempts-- > 0);
         return result;
     };
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,10 @@
-import { debug as d } from "./platform.deno.ts";
+import {
+    type AbortSignal,
+    debug as d,
+    HttpError,
+    type Transformer,
+} from "./platform.deno.ts";
 const debug = d("grammy:auto-retry");
-import { HttpError, type Transformer } from "./platform.deno.ts";
 
 const ONE_HOUR = 3600; // seconds
 const INITIAL_LAST_DELAY = 3; // seconds

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -10,3 +10,8 @@ if (typeof Deno !== "undefined") {
     if (namespace) debug.enable(namespace);
     else debug.disable();
 }
+
+export {
+    HttpError,
+    type Transformer,
+} from "https://lib.deno.dev/x/grammy@v1/mod.ts";

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -15,3 +15,5 @@ export {
     HttpError,
     type Transformer,
 } from "https://lib.deno.dev/x/grammy@v1/mod.ts";
+
+export type AbortSignal = globalThis.AbortSignal;

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,2 +1,3 @@
 export { debug } from "debug";
 export { HttpError, type Transformer } from "grammy";
+export { type AbortSignal } from "abort-controller";

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,1 +1,2 @@
 export { debug } from "debug";
+export { HttpError, type Transformer } from "grammy";


### PR DESCRIPTION
The plugin does not retry HttpErrors yet. This PQ changes that.

This PQ also fixes a big where a request would not be canceled with the signal if it is currently waiting.