### PR TITLE
fix: rethrow HTTP errors when requests are aborted via AbortSignal

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -113,7 +113,10 @@ export function autoRetry(options?: Partial<AutoRetryOptions>): Transformer {
                 try {
                     res = await prev(method, payload, signal);
                 } catch (e) {
-                    if (!rethrowHttpErrors && e instanceof HttpError) {
+                    if (
+                        (signal === undefined || !signal.aborted) &&
+                        !rethrowHttpErrors && e instanceof HttpError
+                    ) {
                         debug(
                             `HttpError thrown, will retry '${method}' after ${nextDelay} seconds (${e.message})`,
                         );


### PR DESCRIPTION
Fixes #18 by rethrowing HTTP errors in case the signal is aborted.